### PR TITLE
Update align.py

### DIFF
--- a/mapalign/align.py
+++ b/mapalign/align.py
@@ -22,7 +22,7 @@ def get_weight_matrix(Acoord, Bcoord, idx):
 
 
 def iterative_alignment(embeddings, n_iters=1):
-    target = embeddings[-1]
+    target = embeddings[0]
     realigned = [target]
     xfms = []
     # first pass


### PR DESCRIPTION
iterative_alignment used embeddings[-1] as its target and subsequently aligned embeddings[1:] which means that embeddings[0] was discarded in the first pass. This has been resolved.