### PR TITLE
Move transition matrix computation outside of main function

### DIFF
--- a/mapalign/dist.py
+++ b/mapalign/dist.py
@@ -127,11 +127,12 @@ def compute_nearest_neighbor_graph(K, n_neighbors=50):
     return K
 
 
-def compute_affinity(X, method='markov', eps=None, metric='euclidean'):
+def compute_affinity(X, method='markov', f_neighbors = 0.01, eps=None, metric='euclidean'):
     """Compute the similarity or affinity matrix between the samples in X
 
     :param X: A set of samples with number of rows > 1
     :param method: 'markov' or 'cauchy' kernel (default: markov)
+    :param f_neighbors: Fraction of nearest neighbors to consider for automatic eps calculation
     :param eps: scaling factor for kernel
     :param metric: metric to compute pairwise distances
     :return: a similarity matrix
@@ -147,8 +148,8 @@ def compute_affinity(X, method='markov', eps=None, metric='euclidean'):
     import numpy as np
     D = squareform(pdist(X, metric=metric))
     if eps is None:
-        k = int(max(2, np.round(D.shape[0] * 0.01)))
-        eps = 2 * np.median(np.sort(D, axis=0)[k+1, :])**2
+        k = int(max(2, np.round(D.shape[0] * f_neighbors)))
+        eps = np.median(np.sort(D, axis=0)[0:k+1, :]**2)
     if method == 'markov':
         affinity_matrix = np.exp(-(D * D) / eps)
     elif method == 'cauchy':

--- a/mapalign/embed.py
+++ b/mapalign/embed.py
@@ -100,11 +100,11 @@ def compute_diffusion_map(L, alpha=0.5, n_components=None, diffusion_time=0,
             L_alpha = L_alpha * d_alpha[np.newaxis, :]
 
     # Step 3
-    d_alpha = np.power(np.array(L_alpha.sum(axis=0)).flatten(), -1)
+    d_alpha = np.power(np.array(L_alpha.sum(axis=1)).flatten(), -1)
     if use_sparse:
         L_alpha.data *= d_alpha[L_alpha.indices]
     else:
-        L_alpha = d_alpha[np.newaxis, :] * L_alpha
+        L_alpha = d_alpha[:, np.newaxis] * L_alpha
 
     M = L_alpha
 
@@ -445,4 +445,3 @@ if has_sklearn:
             """
             self.fit(X)
             return self.embedding_
-

--- a/mapalign/embed.py
+++ b/mapalign/embed.py
@@ -345,7 +345,6 @@ if has_sklearn:
             """
             if self.affinity == 'precomputed':
                 self.affinity_matrix_ = X
-                return self.affinity_matrix_
             if self.affinity == 'nearest_neighbors':
                 if sparse.issparse(X):
                     warnings.warn("Nearest neighbors affinity currently does "
@@ -362,21 +361,16 @@ if has_sklearn:
                     # currently only symmetric affinity_matrix supported
                     self.affinity_matrix_ = 0.5 * (self.affinity_matrix_ +
                                                    self.affinity_matrix_.T)
-                    return self.affinity_matrix_
             if self.affinity == 'rbf':
                 self.gamma_ = (self.gamma
                                if self.gamma is not None else 1.0 / X.shape[1])
                 self.affinity_matrix_ = rbf_kernel(X, gamma=self.gamma_)
-                return self.affinity_matrix_
             if self.affinity in ['markov', 'cauchy']:
                 from .dist import compute_affinity
                 self.affinity_matrix_ = compute_affinity(X,
                                                          method=self.affinity,
                                                          eps=self.gamma,
                                                          metric=self.metric)
-                return self.affinity_matrix_
-            self.affinity_matrix_ = self.affinity(X)
-            return self.affinity_matrix_
 
         def fit(self, X, y=None):
             """Fit the model from data in X.
@@ -413,14 +407,14 @@ if has_sklearn:
                 raise ValueError(("'affinity' is expected to be an affinity "
                                   "name or a callable. Got: %s") % self.affinity)
 
-            affinity_matrix = self._get_affinity_matrix(X)
+            self._get_affinity_matrix(X)
             if self.use_variant:
-                self.embedding_ = compute_diffusion_map_psd(affinity_matrix,
+                self.embedding_ = compute_diffusion_map_psd(self.affinity_matrix_,
                                                             alpha=self.alpha,
                                                             n_components=self.n_components,
                                                             diffusion_time=self.diffusion_time)
             else:
-                self.embedding_ = compute_diffusion_map(affinity_matrix,
+                self.embedding_ = compute_diffusion_map(self.affinity_matrix_,
                                                         alpha=self.alpha,
                                                         n_components=self.n_components,
                                                         diffusion_time=self.diffusion_time,

--- a/mapalign/embed.py
+++ b/mapalign/embed.py
@@ -2,9 +2,13 @@
 """
 
 import numpy as np
+import scipy.sparse as sps
+
 has_sklearn = True
 try:
     import sklearn
+    from sklearn.neighbors import kneighbors_graph
+    from sklearn.metrics.pairwise import rbf_kernel
 except ImportError:
     has_sklearn = False
 
@@ -346,7 +350,7 @@ if has_sklearn:
             if self.affinity == 'precomputed':
                 self.affinity_matrix_ = X
             if self.affinity == 'nearest_neighbors':
-                if sparse.issparse(X):
+                if sps.issparse(X):
                     warnings.warn("Nearest neighbors affinity currently does "
                                   "not support sparse input, falling back to "
                                   "rbf affinity")

--- a/mapalign/embed.py
+++ b/mapalign/embed.py
@@ -100,11 +100,11 @@ def compute_diffusion_map(L, alpha=0.5, n_components=None, diffusion_time=0,
             L_alpha = L_alpha * d_alpha[np.newaxis, :]
 
     # Step 3
-    d_alpha = np.power(np.array(L_alpha.sum(axis=1)).flatten(), -1)
+    d_alpha = np.power(np.array(L_alpha.sum(axis=0)).flatten(), -1)
     if use_sparse:
         L_alpha.data *= d_alpha[L_alpha.indices]
     else:
-        L_alpha = d_alpha[:, np.newaxis] * L_alpha
+        L_alpha = d_alpha[np.newaxis, :] * L_alpha
 
     M = L_alpha
 
@@ -445,3 +445,4 @@ if has_sklearn:
             """
             self.fit(X)
             return self.embedding_
+


### PR DESCRIPTION
Refactoring the kernel normalization and transition matrix computation as independent function will allow for more code re-use. 