### PR TITLE
fix: diffusion time estimate

### DIFF
--- a/mapalign/embed.py
+++ b/mapalign/embed.py
@@ -141,7 +141,7 @@ def _step_5(lambdas, vectors, ndim, n_components, diffusion_time, return_result)
     psi = vectors/vectors[:, [0]]
     diffusion_times = diffusion_time
     if diffusion_time == 0:
-        diffusion_times = np.exp(1. -  np.log(1 - lambdas[1:])/np.log(lambdas[1:]))
+        diffusion_times = 1. -  np.log(1 - lambdas[1:])/np.log(lambdas[1:])
         lambdas = lambdas[1:] / (1 - lambdas[1:])
     else:
         lambdas = lambdas[1:] ** float(diffusion_time)


### PR DESCRIPTION
the exponentiation should not be necessary for estimating the diffusion time corresponding to a scaled eigenvalue.